### PR TITLE
use tisdk npm to install titanium sdk

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,7 @@ RUN \
 RUN ln -s /usr/bin/nodejs /usr/bin/node
 
 # Install Titanium SDK and Alloy
-RUN npm install -g titanium alloy
+RUN npm install -g titanium alloy tisdk
 
 # Grab Android SDK
 RUN cd /opt && \
@@ -47,9 +47,9 @@ RUN cd /opt && \
 # Install Android SDK 23 and additional tools
 RUN echo y | /opt/android-sdk-linux/tools/android update sdk --all --filter android-23,platform-tools,build-tools-21.0.0 --no-ui --force
 
-# Grab Android NDK (r10 instead of r11 due to bug; see TIMOB-20613 for more details)
+# Grab Android NDK
 RUN cd /opt && \
-	wget -nv -O android-ndk.zip https://dl.google.com/android/repository/android-ndk-r10e-linux-x86_64.zip && \
+	wget -nv -O android-ndk.zip https://dl.google.com/android/repository/android-ndk-r12-linux-x86_64.zip && \
 	unzip android-ndk.zip && \
 	rm -f android-ndk.zip
 
@@ -61,13 +61,7 @@ RUN useradd -ms /bin/bash build
 USER build
 
 # Grab Titanium SDK
-RUN mkdir /home/build/.titanium && \
-	cd /home/build/.titanium && \
-	wget -nv -O titanium.zip http://builds.appcelerator.com/mobile-releases/5.2.2/mobilesdk-5.2.2.GA-linux.zip && \
-	unzip titanium.zip && \
-	rm -f titanium.zip
-#RUN titanium sdk install 5.2.2.GA --default #doesn't work due to bug in titanium
-#RUN appc ti sdk install 5.2.2.GA #appc requires login
+RUN tisdk install 6.0.4.GA --force
 
 # Set Android SDK/NDK Environment Variable
 ENV ANDROID_SDK /opt/android-sdk-linux

--- a/README.md
+++ b/README.md
@@ -1,2 +1,8 @@
 # ti.build
-Independend Docker image for building Appcelerator Titanium mobile projects
+Independent Docker image for building Appcelerator Titanium mobile projects
+
+# TODOs
+- [ ] Autodetect SDK version from tiapp.xml
+- [ ] Add example for GitHub & BitBucket Pipelines
+- [ ] Automatic upload to Google Play
+- [ ] Install Alloy only if required

--- a/README.md
+++ b/README.md
@@ -4,5 +4,5 @@ Independent Docker image for building Appcelerator Titanium mobile projects
 # TODOs
 - [ ] Autodetect SDK version from tiapp.xml
 - [ ] Add example for GitHub & BitBucket Pipelines
-- [ ] Automatic upload to Google Play
+- [ ] Support TiFastlane to update Google Play (push builds, update meta ... etc)
 - [ ] Install Alloy only if required


### PR DESCRIPTION
1. Use tisdk npm to install Titanium SDK
2. [TIMOB-20613] solved, so upgrade to latest supported NDK
3. Upgrade to Titanium 6.0.4.GA